### PR TITLE
Acting as as a parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 ## 1.3.1 - 2018-05-23
 ### Added
-- actungAs parameter to Client.ListVariables and Client.ListUsers methods
+- actingAs parameter to Client.ListVariables and Client.ListUsers methods
 ### Removed
 - Client.ActingAs property
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 ## 1.3.1 - 2018-05-23
-### Added
+### Changed
 - actingAs parameter to Client.ListVariables and Client.ListUsers methods
-### Removed
 - Client.ActingAs property
 
 ## 1.3.0 - 2018-05-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+## 1.3.1 - 2018-05-23
+### Added
+- actungAs parameter to Client.ListVariables and Client.ListUsers methods
+### Removed
+- Client.ActingAs property
+
 ## 1.3.0 - 2018-05-22
 ### Added
 - User entity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 ## 1.3.1 - 2018-05-23
 ### Changed
-- actingAs parameter to Client.ListVariables and Client.ListUsers methods
-- Client.ActingAs property
+- Add actingAs parameter to Client.ListVariables and Client.ListUsers methods
+- Remove Client.ActingAs property
 
 ## 1.3.0 - 2018-05-22
 ### Added

--- a/conjur-api/Client.Methods.cs
+++ b/conjur-api/Client.Methods.cs
@@ -30,22 +30,24 @@ namespace Conjur
         /// Search for variables
         /// </summary>
         /// <param name="query">Query for search.</param>
+        /// <param name="actingAs">Fully qualified role name. For example MyCompanyName:group:security_admin. Note support for this value is limited in the current version of this library.</param>
         /// <returns>List of variables matching the query.</returns>
         /// Note enumerating can incur network requests to fetch more data.
-        public IEnumerable<Variable> ListVariables(string query = null)
+        public IEnumerable<Variable> ListVariables(string query = null, string actingAs = null)
         {
-            return Conjur.Variable.List(this, query);
+            return Conjur.Variable.List(this, query, actingAs);
         }
 
         /// <summary>
         /// Search for users
         /// </summary>
         /// <param name="query">Query for search.</param>
+        /// <param name="actingAs">Fully qualified role name. For example MyCompanyName:group:security_admin. Note support for this value is limited in the current version of this library.</param>
         /// <returns>List of users matching the query.</returns>
         /// Note enumerating can incur network requests to fetch more data.
-        public IEnumerable<User> ListUsers(string query = null)
+        public IEnumerable<User> ListUsers(string query = null, string actingAs = null)
         {
-            return Conjur.User.List(this, query);
+            return Conjur.User.List(this, query, actingAs);
         }
 
         /// <summary>

--- a/conjur-api/Client.cs
+++ b/conjur-api/Client.cs
@@ -35,13 +35,6 @@ namespace Conjur
         }
 
         /// <summary>
-        /// Switch the client to ActingAs another role. Set to null by default.
-        /// </summary>
-        /// Note support for this value is limited in the current version of this library.
-        /// <value>Fully qualified role name. For example MyCompanyName:group:security_admin.</value>
-        public string ActingAs { get; set; }
-
-        /// <summary>
         /// Gets the appliance URI.
         /// </summary>
         /// <value>The appliance URI.</value>

--- a/conjur-api/Properties/AssemblyInfo.cs
+++ b/conjur-api/Properties/AssemblyInfo.cs
@@ -19,7 +19,7 @@ using System.Runtime.CompilerServices;
 /// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
 /// The form "{Major}.{Minor}.*" will automatically update the build and revision,
 /// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-[assembly: AssemblyVersion("1.3.0.*")]
+[assembly: AssemblyVersion("1.3.1.*")]
 
 #if (!SIGNING)
 [assembly: InternalsVisibleTo("ConjurTest")]

--- a/conjur-api/Resource.cs
+++ b/conjur-api/Resource.cs
@@ -50,8 +50,9 @@ namespace Conjur
         /// <param name="client">Conjur client to query.</param>
         /// <param name="kind">Resource kind to query.</param>
         /// <param name="query">Query for search.</param>
+        /// <param name="actingAs">Fully qualified role name. For example MyCompanyName:group:security_admin.</param>
         /// <returns>Returns IEnumerable<T>.</returns>
-        internal static IEnumerable<T> ListResources<T, TResult>(Client client, string kind, Func<TResult, T> newT, string query = null) 
+        internal static IEnumerable<T> ListResources<T, TResult>(Client client, string kind, Func<TResult, T> newT, string query = null, string actingAs = null) 
         {
             uint offset = 0;
             List<TResult> resultList;
@@ -60,7 +61,7 @@ namespace Conjur
                 string urlWithParams = $"authz/{client.GetAccountName()}/resources/{kind}?offset={offset}"
                                       + $"&limit={LIMIT_SEARCH_VAR_LIST_RETURNED}"
                                       + ((query != null) ? $"&search={query}" : string.Empty)
-                                      + ((client.ActingAs != null) ? $"&acting_as={client.ActingAs}" : string.Empty);
+                                      + ((actingAs != null) ? $"&acting_as={actingAs}" : string.Empty);
 
                 resultList = JsonSerializer<List<TResult>>.Read(client.AuthenticatedRequest(urlWithParams));
                 foreach (TResult searchVarResult in resultList)

--- a/conjur-api/User.cs
+++ b/conjur-api/User.cs
@@ -32,10 +32,10 @@ namespace Conjur
         /// <param name="client">Conjur client to query.</param>
         /// <param name="query">Query for search.</param>
         /// <returns>Returns IEnumerable to User.</returns>
-        internal static IEnumerable<User> List(Client client, string query = null)
+        internal static IEnumerable<User> List(Client client, string query = null, string actingAs = null)
         {
             Func<ResourceMetadata, User> newInst = (searchRes) => new User(client, searchRes.Id);
-            return ListResources<User, ResourceMetadata>(client, "user", newInst, query);
+            return ListResources<User, ResourceMetadata>(client, "user", newInst, query, actingAs);
         }
     }
 }

--- a/conjur-api/Variable.cs
+++ b/conjur-api/Variable.cs
@@ -68,10 +68,10 @@ namespace Conjur
         /// <param name="client">Conjur client to query.</param>
         /// <param name="query">Query for search.</param>
         /// <returns>Returns IEnumerable to Variable.</returns>
-        internal static IEnumerable<Variable> List(Client client, string query = null)
+        internal static IEnumerable<Variable> List(Client client, string query = null, string actingAs = null)
         {
             Func<ResourceMetadata, Variable> newInst = (searchRes) => new Variable(client, searchRes.Id);
-            return ListResources<Variable, ResourceMetadata>(client, "variable", newInst, query);
+            return ListResources<Variable, ResourceMetadata>(client, "variable", newInst, query, actingAs);
         }
     }
 }

--- a/test/UsersTest.cs
+++ b/test/UsersTest.cs
@@ -33,16 +33,15 @@ namespace Conjur.Test
 
             // Verify parameters of GetListVariables() passed as expected toward conjur server
             ClearMocker();
-            Client.ActingAs = "user:role";
             Mocker.Mock(new Uri($"{userListUrl}?offset=0&limit=1000&search=user_0&acting_as=user:role"), GenerateUsersInfo(0, 1000));
             Mocker.Mock(new Uri($"{userListUrl}?offset=1000&limit=1000&search=user_0&acting_as=user:role"), GenerateUsersInfo(1000, 1872));
             Mocker.Mock(new Uri($"{userListUrl}?offset=1872&limit=1000&search=user_0&acting_as=user:role"), "[]");
-            users =(Client.ListUsers("user_0")).GetEnumerator();
+            users =(Client.ListUsers("user_0", "user:role")).GetEnumerator();
             VerifyUsersInfo(users, 1872);
 
             // Check handling invalid json response from conjur server
             ClearMocker();
-            Mocker.Mock(new Uri($"{userListUrl}?offset=0&limit=1000&acting_as=user:role"), @"[""id"":""ivnalidjson""]");
+            Mocker.Mock(new Uri($"{userListUrl}?offset=0&limit=1000"), @"[""id"":""ivnalidjson""]");
             users = Client.ListUsers().GetEnumerator();
             Assert.Throws<SerializationException>(() => users.MoveNext());
         }

--- a/test/VariablesTest.cs
+++ b/test/VariablesTest.cs
@@ -58,16 +58,15 @@ namespace Conjur.Test
 
             // Verify parameters of GetListVariables() passed as expected toward conjur server
             ClearMocker();
-            Client.ActingAs = "user:role";
             Mocker.Mock(new Uri($"{varListUrl}?offset=0&limit=1000&search=var_0&acting_as=user:role"), GenerateVariablesInfo(0, 1000));
             Mocker.Mock(new Uri($"{varListUrl}?offset=1000&limit=1000&search=var_0&acting_as=user:role"), GenerateVariablesInfo(1000, 1872));
             Mocker.Mock(new Uri($"{varListUrl}?offset=1872&limit=1000&search=var_0&acting_as=user:role"), "[]");
-            vars = (Client.ListVariables("var_0")).GetEnumerator();
+            vars = (Client.ListVariables("var_0", "user:role")).GetEnumerator();
             verifyVariablesInfo(vars, 1872);
 
             // Check handling invalid json response from conjur server
             ClearMocker();
-            Mocker.Mock(new Uri($"{varListUrl}?offset=0&limit=1000&acting_as=user:role"), @"[""id"":""ivnalidjson""]");
+            Mocker.Mock(new Uri($"{varListUrl}?offset=0&limit=1000"), @"[""id"":""ivnalidjson""]");
             vars = (Client.ListVariables()).GetEnumerator();
             Assert.Throws<SerializationException>(() => vars.MoveNext());
         }


### PR DESCRIPTION
ActingAs property has a branch of problem

- It's not thread safe, separated threads can't use different ActingAs context
- ActingAs is a parameter of only 8 Conjur REST APIs from more then 40 so it is not obvious from SDK which APIs are affected from the property and which aren't
- If there are two separated code areas that use the same client instance they always need to check and to overwrite ActingAs value before relevant calls (but which calls are relevant is not obvious, as I mentioned)