### PR TITLE
Adding Role entity and all related APIs: Exists, Members and Memberships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-## 1.4.0 - 2018-07-04
+## 1.4.0 - 2018-07-05
 - Add Role entity with all corresponding methods
 
 ## 1.3.0 - 2018-05-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+## 1.4.0 - 2018-07-04
+- Add Role entity with all corresponding methods
+
 ## 1.3.0 - 2018-05-22
 ### Added
 - User entity

--- a/conjur-api/Client.Methods.cs
+++ b/conjur-api/Client.Methods.cs
@@ -51,6 +51,19 @@ namespace Conjur
         }
 
         /// <summary>
+        /// Creates an object representing the Role
+        /// </summary>
+        /// Note the existence of the Role is not verified.
+        /// <returns>The role object.</returns>
+        /// <param name="kind">Kind: 'group', 'layer' etc.</param>
+        /// <param name="name">The role Name.</param>
+        /// <seealso cref="Role()"/>
+        public Role Role(string kind, string name)
+        {
+            return new Role(this, kind, name);
+        }
+
+        /// <summary>
         /// Search for users
         /// </summary>
         /// <param name="query">Query for search.</param>

--- a/conjur-api/Properties/AssemblyInfo.cs
+++ b/conjur-api/Properties/AssemblyInfo.cs
@@ -19,7 +19,7 @@ using System.Runtime.CompilerServices;
 /// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
 /// The form "{Major}.{Minor}.*" will automatically update the build and revision,
 /// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-[assembly: AssemblyVersion("1.3.0.*")]
+[assembly: AssemblyVersion("1.4.0.*")]
 
 #if (!SIGNING)
 [assembly: InternalsVisibleTo("ConjurTest")]

--- a/conjur-api/Resource.cs
+++ b/conjur-api/Resource.cs
@@ -57,7 +57,7 @@ namespace Conjur
             List<TResult> resultList;
             do
             {
-                string urlWithParams = $"authz/{client.GetAccountName()}/resources/{kind}?offset={offset}"
+                string urlWithParams = $"authz/{WebUtility.UrlEncode(client.GetAccountName())}/resources/{kind}?offset={offset}"
                                       + $"&limit={LIMIT_SEARCH_VAR_LIST_RETURNED}"
                                       + ((query != null) ? $"&search={query}" : string.Empty)
                                       + ((client.ActingAs != null) ? $"&acting_as={client.ActingAs}" : string.Empty);

--- a/conjur-api/ResourceMetadata.cs
+++ b/conjur-api/ResourceMetadata.cs
@@ -59,4 +59,16 @@ namespace Conjur
         public string UpdatedAt { get; private set; }
     }
 
+    [DataContract]
+    public class RoleMember
+    {
+        [DataMember(Name = "admin_option")]
+        public bool Admin { get; set; }
+        [DataMember(Name = "grantor")]
+        public string Grantor { get; set; }
+        [DataMember(Name = "member")]
+        public string Member { get; set; }
+        [DataMember(Name = "role")]
+        public string Role { get; set; }
+    }
 }

--- a/conjur-api/Role.cs
+++ b/conjur-api/Role.cs
@@ -28,7 +28,7 @@ namespace Conjur
         internal Role(Client client, string kind, string name)
             : base(client, kind, name)
         {
-            this.path = $"authz/{client.GetAccountName()}/roles/{WebUtility.UrlEncode(kind)}/{WebUtility.UrlEncode(name)}";
+            this.path = $"authz/{WebUtility.UrlEncode(client.GetAccountName())}/roles/{WebUtility.UrlEncode(kind)}/{WebUtility.UrlEncode(name)}";
         }
 
         /// <summary>

--- a/conjur-api/Role.cs
+++ b/conjur-api/Role.cs
@@ -1,0 +1,80 @@
+// <copyright file="Role.cs" company="Conjur Inc.">
+//     Copyright (c) 2018 Cyberark Ltd. All rights reserved.
+// </copyright>
+// <summary>
+//     Role manipulation routines.
+// </summary>
+
+namespace Conjur
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+
+    /// <summary>
+    /// Conjur Role reference.
+    /// </summary>
+    /// A role is an actor in the system, in the classical sense of role-based access control. Roles are the entities which receive permission grants.
+    public class Role : Resource
+    {
+        private readonly string path;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Conjur.Role"/> class.
+        /// </summary>
+        /// <param name="client">Conjur client to use to connect.</param>
+        /// <param name="kind">Kind of the role, for example 'group' or 'layer'.</param>
+        /// <param name="name">The Role name.</param>
+        internal Role(Client client, string kind, string name)
+            : base(client, kind, name)
+        {
+            this.path = $"authz/{client.GetAccountName()}/roles/{WebUtility.UrlEncode(kind)}/{WebUtility.UrlEncode(name)}";
+        }
+
+        /// <summary>
+        /// Check for the existence of a role.
+        /// </summary>
+        /// <returns>True if role exists otherwice false.</returns>
+        /// Only roles that you have read permission on will be searched.
+        public bool Exists()
+        {
+            WebRequest webRequest = this.Client.AuthenticatedRequest(this.path);
+            webRequest.Method = WebRequestMethods.Http.Head;
+            try
+            {
+                webRequest.GetResponse().Close();                
+            }
+            catch (WebException ex)
+            {
+                HttpWebResponse responce = ex.Response as HttpWebResponse;
+                if (responce != null && responce.StatusCode == HttpStatusCode.NotFound)
+                {
+                    return false;
+                }
+
+                throw;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Lists the roles that have been the recipient of a role grant.
+        /// </summary>
+        /// <returns>Returns IEnumerable RoleMember.</returns>
+        /// The creator of the role is always a role member and role administrator.
+        public IEnumerable<RoleMember> ListMembers()
+        {
+            return JsonSerializer<List<RoleMember>>.Read(this.Client.AuthenticatedRequest($"{this.path}?members"));
+        }
+
+        /// <summary>
+        /// List the roles a role is a member of.
+        /// </summary>
+        /// <returns>Returns IEnumerable role ids.</returns>
+        public IEnumerable<string> ListMemberships()
+        {
+            return JsonSerializer<List<string>>.Read(this.Client.AuthenticatedRequest($"{this.path}?all"));
+        }
+    }
+}

--- a/conjur-api/Role.cs
+++ b/conjur-api/Role.cs
@@ -14,7 +14,7 @@ namespace Conjur
     /// <summary>
     /// Conjur Role reference.
     /// </summary>
-    /// A role is an actor in the system, in the classical sense of role-based access control. Roles are the entities which receive permission grants.
+    /// <remarks>A role is an actor in the system, in the classical sense of role-based access control. Roles are the entities which receive permission grants.</remarks>
     public class Role : Resource
     {
         private readonly string path;
@@ -35,7 +35,7 @@ namespace Conjur
         /// Check for the existence of a role.
         /// </summary>
         /// <returns>True if role exists otherwice false.</returns>
-        /// Only roles that you have read permission on will be searched.
+        /// <remarks>Only roles that you have read permission on will be searched.</remarks>
         public bool Exists()
         {
             WebRequest webRequest = this.Client.AuthenticatedRequest(this.path);
@@ -46,8 +46,8 @@ namespace Conjur
             }
             catch (WebException ex)
             {
-                HttpWebResponse responce = ex.Response as HttpWebResponse;
-                if (responce != null && responce.StatusCode == HttpStatusCode.NotFound)
+                HttpWebResponse response = ex.Response as HttpWebResponse;
+                if (response != null && response.StatusCode == HttpStatusCode.NotFound)
                 {
                     return false;
                 }
@@ -62,7 +62,7 @@ namespace Conjur
         /// Lists the roles that have been the recipient of a role grant.
         /// </summary>
         /// <returns>Returns IEnumerable RoleMember.</returns>
-        /// The creator of the role is always a role member and role administrator.
+        /// <remarks>The creator of the role is always a role member and role administrator.</remarks>
         public IEnumerable<RoleMember> ListMembers()
         {
             return JsonSerializer<List<RoleMember>>.Read(this.Client.AuthenticatedRequest($"{this.path}?members"));

--- a/conjur-api/conjur-api.csproj
+++ b/conjur-api/conjur-api.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Resource.cs" />
     <Compile Include="Client.Methods.cs" />
     <Compile Include="ResourceMetadata.cs" />
+    <Compile Include="Role.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/test/RoleTest.cs
+++ b/test/RoleTest.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Net;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using static Conjur.Test.WebMocker;
+using System.Text;
+using System.Linq;
+
+namespace Conjur.Test
+{
+    public class RoleTest : Base
+    {
+        private string baseUrl = "test:///authz/test-account/roles/group";
+        
+        public RoleTest()
+        {
+            Client.Authenticator = new MockAuthenticator();
+        }
+
+        [Test]
+        public void TestRoleDoesExist()
+        {
+            ClearMocker();
+            Mocker.Mock(new Uri($"{baseUrl}/groupName"), "");
+            Assert.IsTrue(Client.Role("group", "groupName").Exists(), "Group 'groupName' expected to be exist");
+        }
+
+        [Test]
+        public void TestRoleDoesNotExist()
+        {
+            ClearMocker();
+            MockRequest mock = Mocker.Mock(new Uri($"{baseUrl}/groupName"), "");
+            mock.Verifier = (wr) => 
+            {
+                throw new WebMocker.MockResponseException(HttpStatusCode.NotFound, "NotFound");
+            };
+
+            Assert.IsFalse(Client.Role("group", "groupName").Exists(), "Group 'groupName' expected to be not exist");
+        }
+
+        [Test]
+        public void TestRoleMembers()
+        {
+            ClearMocker();
+            Mocker.Mock(new Uri($"{baseUrl}/groupName?members"), GenerateMembersData(10));
+            VerifyRoleInfo(Client.Role("group", "groupName").ListMembers().GetEnumerator(), 10);
+        }
+
+        [Test]
+        public void TestRoleMemberships()
+        {
+            ClearMocker();
+            Mocker.Mock(new Uri($"{baseUrl}/groupName?all"), "[ \"role0\", \"role1\" ]");
+            string[] roles = Client.Role("group", "groupName").ListMemberships().ToArray();
+            Assert.AreEqual("role0", roles[0]);
+            Assert.AreEqual("role1", roles[1]);
+        }
+
+        private void VerifyRoleInfo(IEnumerator<RoleMember> members, int expectedNum)
+        {
+            for(int id = 0; id < expectedNum; id++)
+            {
+                Assert.AreEqual(true, members.MoveNext());
+                Assert.AreEqual($"theMember{id}", members.Current.Member);
+            }
+            Assert.AreEqual(false, members.MoveNext());
+        }
+
+        private string GenerateMembersData(int count)
+        {
+            StringBuilder stringBuilder = new StringBuilder();
+
+            for(int id = 0; id < count; id++) 
+            {
+                stringBuilder.Append($"{{\"admin_option\": {(id % 2 == 0).ToString().ToLower()},");
+                stringBuilder.Append($"\"grantor\":\"theGrantor\",");
+                stringBuilder.Append($"\"member\":\"theMember{id}\",");
+                stringBuilder.Append($"\"role\":\"theRole\"}}");
+                stringBuilder.Append(",");
+            }
+            stringBuilder.Remove(stringBuilder.Length - 1, 1);
+            return $"[{stringBuilder}]";
+        }
+    }
+}

--- a/test/RoleTest.cs
+++ b/test/RoleTest.cs
@@ -22,7 +22,7 @@ namespace Conjur.Test
         public void TestRoleDoesExist()
         {
             ClearMocker();
-            Mocker.Mock(new Uri($"{baseUrl}/groupName"), "");
+            Mocker.Mock(new Uri($"{baseUrl}/groupName"), string.Empty);
             Assert.IsTrue(Client.Role("group", "groupName").Exists(), "Group 'groupName' expected to be exist");
         }
 
@@ -30,7 +30,7 @@ namespace Conjur.Test
         public void TestRoleDoesNotExist()
         {
             ClearMocker();
-            MockRequest mock = Mocker.Mock(new Uri($"{baseUrl}/groupName"), "");
+            MockRequest mock = Mocker.Mock(new Uri($"{baseUrl}/groupName"), string.Empty);
             mock.Verifier = (wr) => 
             {
                 throw new WebMocker.MockResponseException(HttpStatusCode.NotFound, "NotFound");
@@ -53,6 +53,7 @@ namespace Conjur.Test
             ClearMocker();
             Mocker.Mock(new Uri($"{baseUrl}/groupName?all"), "[ \"role0\", \"role1\" ]");
             string[] roles = Client.Role("group", "groupName").ListMemberships().ToArray();
+            Assert.AreEqual (2, roles.Length);
             Assert.AreEqual("role0", roles[0]);
             Assert.AreEqual("role1", roles[1]);
         }

--- a/test/test.csproj
+++ b/test/test.csproj
@@ -45,6 +45,7 @@
     <Compile Include="CertificateVerificationTest.cs" />
     <Compile Include="Certificates.cs" />
     <Compile Include="AuthenticatorTest.cs" />
+    <Compile Include="RoleTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
**What does this pull request do?**
Exposes Role related APIs: [Exists](https://conjur.docs.apiary.io/#reference/role/exists/determine-whether-a-role-exists), [Members](https://conjur.docs.apiary.io/#reference/role/list-members/lists-the-roles-that-have-been-the-recipient-of-a-role-grant) and [Memberships](https://conjur.docs.apiary.io/#reference/role/list-memberships/list-the-roles-a-role-is-a-member-of).
**What background context can you provide?**
This functionality is nesessary in Vault-Conjur Synchroniser.
We want to be sure that users and groups that we created related each other as expected.
**Where should the reviewer start?**
conjur-api/Role.cs