### PR TITLE
Improve thread-safety of the API key authenticator

### DIFF
--- a/test/AuthenticatorTest.cs
+++ b/test/AuthenticatorTest.cs
@@ -7,33 +7,94 @@ namespace Conjur.Test
 {
     public class AuthenticatorTest : Base
     {
-        [Test]
-        public void TestTokenCaching()
+        static protected readonly NetworkCredential credential = new NetworkCredential("username", "api-key");
+
+        protected ApiKeyAuthenticator Authenticator;
+        
+        [SetUp]
+        public void CreateAuthenticator ()
         {
+            Authenticator = new ApiKeyAuthenticator(new Uri("test:///authn"), TestAccount, credential);
+        }
+
+        [Test]
+        public void TestTokenCaching ()
+        {
+            MockToken("token1");
+            Assert.AreEqual("token1", Authenticator.GetToken());
+            MockToken("token2");
+
+            Assert.AreEqual("token1", Authenticator.GetToken());
+            MockTokenExpiration ();
+            Assert.AreEqual("token2", Authenticator.GetToken());
+        }
+
+        [Test]
+        public void TestTokenThreadSafe ()
+        {
+            int authenticationCount = 0;
             Action<WebRequest> verifier = (WebRequest wr) =>
             {
-                var req = wr as WebMocker.MockRequest;
-                Assert.AreEqual("POST", wr.Method);
-                Assert.AreEqual("api-key", req.Body);
+                ApiKeyVerifier(wr);
+                Thread.Sleep (10);
+                Interlocked.Increment(ref authenticationCount);
             };
 
-            Mocker.Mock(new Uri("test:///authn/" + TestAccount + "/" + LoginName + "/authenticate"), "token1")
-                .Verifier = verifier;
+            string token = "token1";
 
-            var credential = new NetworkCredential(LoginName, "api-key");
-            var authenticator = new ApiKeyAuthenticator(new Uri("test:///authn"), TestAccount ,credential);
+            MockToken(token).Verifier = verifier;
 
-            Assert.AreEqual("token1", authenticator.GetToken());
+            Assert.AreEqual(token, Authenticator.GetToken());
+            Assert.AreEqual(1, authenticationCount);
 
-            Mocker.Mock(new Uri("test:///authn/" + TestAccount + "/" + LoginName + "/authenticate"), "token2")
-                .Verifier = verifier;
+            ThreadStart checker = () =>
+            {
+                Assert.AreEqual(token, Authenticator.GetToken());
+            };
 
-            Assert.AreEqual("token1", authenticator.GetToken());
+            Thread t1 = new Thread(checker);
+            Thread t2 = new Thread(checker);
 
-            authenticator.StartTokenTimer(new TimeSpan(0, 0, 0, 0, 1));
-            Thread.Sleep(10);
+            t1.Start(); t2.Start();
+            t1.Join(); t2.Join();
 
-            Assert.AreEqual("token2", authenticator.GetToken());
+            Assert.AreEqual(1, authenticationCount);
+
+            MockTokenExpiration();
+
+            token = "token2";
+            MockToken(token).Verifier = verifier;
+
+            t1 = new Thread(checker);
+            t2 = new Thread(checker);
+
+            Assert.AreEqual(1, authenticationCount);
+            t1.Start(); t2.Start();
+            t1.Join(); t2.Join();
+            Assert.AreEqual(2, authenticationCount);
         }
+
+        static protected readonly Action<WebRequest> ApiKeyVerifier = (WebRequest wr) =>
+        {
+            var req = wr as WebMocker.MockRequest;
+            Assert.AreEqual("POST", wr.Method);
+            Assert.AreEqual("api-key", req.Body);
+        };
+
+
+        protected WebMocker.MockRequest MockToken (string token)
+        {
+            var mock = Mocker.Mock(new Uri($"test:///authn/{TestAccount}/username/authenticate"), token);
+            mock.Verifier = ApiKeyVerifier;
+            return mock;
+        }
+
+        protected void MockTokenExpiration ()
+        {
+            Authenticator.StartTokenTimer (new TimeSpan (0, 0, 0, 0, 1));
+            Thread.Sleep (10);
+        }
+
+
     }
 }

--- a/test/AuthenticatorTest.cs
+++ b/test/AuthenticatorTest.cs
@@ -12,13 +12,13 @@ namespace Conjur.Test
         protected ApiKeyAuthenticator Authenticator;
         
         [SetUp]
-        public void CreateAuthenticator ()
+        public void CreateAuthenticator()
         {
             Authenticator = new ApiKeyAuthenticator(new Uri("test:///authn"), TestAccount, credential);
         }
 
         [Test]
-        public void TestTokenCaching ()
+        public void TestTokenCaching()
         {
             MockToken("token1");
             Assert.AreEqual("token1", Authenticator.GetToken());
@@ -30,7 +30,7 @@ namespace Conjur.Test
         }
 
         [Test]
-        public void TestTokenThreadSafe ()
+        public void TestTokenThreadSafe()
         {
             int authenticationCount = 0;
             Action<WebRequest> verifier = (WebRequest wr) =>
@@ -82,19 +82,17 @@ namespace Conjur.Test
         };
 
 
-        protected WebMocker.MockRequest MockToken (string token)
+        protected WebMocker.MockRequest MockToken(string token)
         {
             var mock = Mocker.Mock(new Uri($"test:///authn/{TestAccount}/username/authenticate"), token);
             mock.Verifier = ApiKeyVerifier;
             return mock;
         }
 
-        protected void MockTokenExpiration ()
+        protected void MockTokenExpiration()
         {
             Authenticator.StartTokenTimer (new TimeSpan (0, 0, 0, 0, 1));
             Thread.Sleep (10);
         }
-
-
     }
 }

--- a/test/AuthenticatorTest.cs
+++ b/test/AuthenticatorTest.cs
@@ -91,8 +91,8 @@ namespace Conjur.Test
 
         protected void MockTokenExpiration()
         {
-            Authenticator.StartTokenTimer (new TimeSpan (0, 0, 0, 0, 1));
-            Thread.Sleep (10);
+            Authenticator.StartTokenTimer(new TimeSpan(0, 0, 0, 0, 1));
+            Thread.Sleep(10);
         }
     }
 }


### PR DESCRIPTION
**What does this pull request do?**
Improves thread-safety of ApiKeyAuthentifiactor class.
**What background context can you provide?**
This functionality is nesessary in Vault-Conjur Synchroniser.
After LogIn, Client instance passes to multi threaded code. We need to be sure that there is no race condition when token expires.
There is similar [pull request](https://github.com/cyberark/conjur-api-dotnet/pull/7) for Conjur v4 api.
**Where should the reviewer start?**
conjur-api/ApiKeyAuthenticator.cs