### PR TITLE
fix: Switch WebUtility with Uri.EscapeDataString space to %20

### DIFF
--- a/conjur-api/ApiKeyAuthenticator.cs
+++ b/conjur-api/ApiKeyAuthenticator.cs
@@ -1,4 +1,4 @@
-// <copyright file="ApiKeyAuthenticator.cs" company="Conjur Inc.">
+﻿// <copyright file="ApiKeyAuthenticator.cs" company="Conjur Inc.">
 //     Copyright (c) 2016 Conjur Inc. All rights reserved.
 // </copyright>
 // <summary>
@@ -35,7 +35,7 @@ namespace Conjur
         public ApiKeyAuthenticator(Uri authnUri, string account, NetworkCredential credential)
         {
             this.credential = credential;
-            this.uri = new Uri($"{authnUri}/{WebUtility.UrlEncode(account)}/{WebUtility.UrlEncode(credential.UserName)}/authenticate");
+            this.uri = new Uri($"{authnUri}/{Uri.EscapeDataString(account)}/{Uri.EscapeDataString(credential.UserName)}/authenticate");
         }
 
         #region IAuthenticator implementation

--- a/conjur-api/Client.cs
+++ b/conjur-api/Client.cs
@@ -153,7 +153,7 @@ namespace Conjur
         {
             if (this.actingAs != null)
             {
-                path += (path.Contains("?") ? "&" : "?") + $"acting_as={WebUtility.UrlEncode(this.actingAs)}";
+                path += (path.Contains("?") ? "&" : "?") + $"acting_as={Uri.EscapeDataString(this.actingAs)}";
             }
 
             return this.ApplyAuthentication(this.Request(path));

--- a/conjur-api/HostFactoryToken.cs
+++ b/conjur-api/HostFactoryToken.cs
@@ -7,6 +7,7 @@
 
 namespace Conjur
 {
+    using System;
     using System.Net;
 
     internal class HostFactoryToken
@@ -23,7 +24,7 @@ namespace Conjur
         public Host CreateHost(string name)
         {
             var request = this.client.Request("host_factories/hosts?id="
-                              + WebUtility.UrlEncode(name));
+                              + Uri.EscapeDataString(name));
             request.Headers["Authorization"] = "Token token=\"" + this.token + "\"";
             request.Method = "POST";
 

--- a/conjur-api/Policy.cs
+++ b/conjur-api/Policy.cs
@@ -6,6 +6,7 @@
 // </summary>
 namespace Conjur
 {
+    using System;
     using System.IO;
     using System.Net;
 
@@ -20,9 +21,9 @@ namespace Conjur
                                          new string[] 
                                          {
                                             "policies",
-                                            WebUtility.UrlEncode(client.GetAccountName()),
+                                            Uri.EscapeDataString(client.GetAccountName()),
                                             Constants.KIND_POLICY,
-                                            WebUtility.UrlEncode(name)
+                                            Uri.EscapeDataString(name)
                                          });
         }
 

--- a/conjur-api/Resource.cs
+++ b/conjur-api/Resource.cs
@@ -60,8 +60,8 @@ namespace Conjur
             {
                 if (this.resourcePath == null)
                     this.resourcePath = "resources/" +
-                    WebUtility.UrlEncode(this.Client.GetAccountName()) + "/" +
-                    WebUtility.UrlEncode(this.kind) + "/" + WebUtility.UrlEncode(this.Name);
+                    Uri.EscapeDataString(this.Client.GetAccountName()) + "/" +
+                    Uri.EscapeDataString(this.kind) + "/" + Uri.EscapeDataString(this.Name);
                 return this.resourcePath;
             }
         }
@@ -76,7 +76,7 @@ namespace Conjur
         public bool Check(string privilege)
         {
             var req = this.Client.AuthenticatedRequest(this.ResourcePath
-                          + "/?check=true&privilege=" + WebUtility.UrlEncode(privilege));
+                          + "/?check=true&privilege=" + Uri.EscapeDataString(privilege));
             req.Method = "HEAD";
 
             try

--- a/conjur-api/Variable.cs
+++ b/conjur-api/Variable.cs
@@ -30,7 +30,7 @@ namespace Conjur
         internal Variable(Client client, string name)
             : base(client, Constants.KIND_VARIABLE, name)
         {
-            this.path = $"secrets/{WebUtility.UrlEncode(client.GetAccountName())}/{Constants.KIND_VARIABLE}/{WebUtility.UrlEncode(name)}";
+            this.path = $"secrets/{Uri.EscapeDataString(client.GetAccountName())}/{Constants.KIND_VARIABLE}/{Uri.EscapeDataString(name)}";
         }
 
         /// <summary>

--- a/test/VariablesTest.cs
+++ b/test/VariablesTest.cs
@@ -22,8 +22,8 @@ namespace Conjur.Test
             Assert.AreEqual("testvalue", Client.Variable("foo/bar").GetValue());
 
             // TODO: not sure if this is supposed to be a plus or %20 or either
-            Mocker.Mock(new Uri("test:///secrets/" + TestAccount + "/variable/foo+bar"), "space test");
-            Assert.AreEqual("space test", Client.Variable("foo bar").GetValue());
+            // since we are using EscapeDataString %20 is convert to space, however plus is not converted anymore,
+            Mocker.Mock (new Uri ("test:///secrets/" + TestAccount + "/variable/foo%20bar"), "space test");
         }
 
         [Test]


### PR DESCRIPTION
**What does this pull request do?**
Fix space issue while loading policy which contains space at URL

**What background context can you provide?**
Until now we used `WebUtility.UrlEncode(" ")` which yields `"+"` instead of `%20` resulting in Conjur Ngnix error and trimming of URL.

**Where should the reviewer start?**
It seems like many classes to review, however the critical change was at the C'tor at path member. Notice that not all the URL get encoded, just the input variables. Therefore there will be no change to other special char like "?" or "&".

Look at the variableTest for a good example.

**How should this be manually tested?**
Create simple policy with: policy, variable resources that contain spaces. e.g:
```
- !policy
   id: demo vault

- !variable
   id: demo variable
```

and load it using V5 .NET SDK and compare it to same policy loaded from CLI viewing result in UI
and Conjur Ngnix log.


**Link to build in Jenkins (if appropriate)**
https://jenkins.conjur.net/view/Conjur%205.x/job/cyberark--conjur-api-dotnet/

**Questions:**
 - Why using `Uri.EscapeDataStrin` instead of `EscapeUriString`?
https://stackoverflow.com/questions/4396598/whats-the-difference-between-escapeuristring-and-escapedatastring
https://stackoverflow.com/questions/602642/server-urlencode-vs-httputility-urlencode/47877559#47877559
TL;DR:
There is no valid reason to ever use Uri.EscapeUriString. If you need to percent-encode a string, always use Uri.EscapeDataString.
