### PR TITLE
fix: Switch WebUtility with Uri.EscapeDataString space to %20 (V4)

### DIFF
--- a/conjur-api/ApiKeyAuthenticator.cs
+++ b/conjur-api/ApiKeyAuthenticator.cs
@@ -34,7 +34,7 @@ namespace Conjur
         {
             this.credential = credential;
             this.uri = new Uri(authnUri + "/users/"
-                + WebUtility.UrlEncode(credential.UserName)
+                + Uri.EscapeDataString(credential.UserName)
                 + "/authenticate");
             this.timer = new Timer((_) => Interlocked.Exchange(ref this.token, null));
         }

--- a/conjur-api/HostFactoryToken.cs
+++ b/conjur-api/HostFactoryToken.cs
@@ -7,6 +7,7 @@
 
 namespace Conjur
 {
+    using System;
     using System.Net;
 
     internal class HostFactoryToken
@@ -23,7 +24,7 @@ namespace Conjur
         public Host CreateHost(string name)
         {
             var request = this.client.Request("host_factories/hosts?id="
-                              + WebUtility.UrlEncode(name));
+                              + Uri.EscapeDataString(name));
             request.Headers["Authorization"] = "Token token=\"" + this.token + "\"";
             request.Method = "POST";
 

--- a/conjur-api/Resource.cs
+++ b/conjur-api/Resource.cs
@@ -57,7 +57,7 @@ namespace Conjur
             List<TResult> resultList;
             do
             {
-                string urlWithParams = $"authz/{WebUtility.UrlEncode(client.GetAccountName())}/resources/{kind}?offset={offset}"
+                string urlWithParams = $"authz/{Uri.EscapeDataString(client.GetAccountName())}/resources/{kind}?offset={offset}"
                                       + $"&limit={LIMIT_SEARCH_VAR_LIST_RETURNED}"
                                       + ((query != null) ? $"&search={query}" : string.Empty)
                                       + ((client.ActingAs != null) ? $"&acting_as={client.ActingAs}" : string.Empty);
@@ -82,8 +82,8 @@ namespace Conjur
             {
                 if (this.resourcePath == null)
                     this.resourcePath = "authz/" +
-                    WebUtility.UrlEncode(this.Client.GetAccountName()) + "/resources/" +
-                    WebUtility.UrlEncode(this.kind) + "/" + WebUtility.UrlEncode(this.Id);
+                    Uri.EscapeDataString(this.Client.GetAccountName()) + "/resources/" +
+                    Uri.EscapeDataString(this.kind) + "/" + Uri.EscapeDataString(this.Id);
                 return this.resourcePath;
             }
         }
@@ -98,7 +98,7 @@ namespace Conjur
         public bool Check(string privilege)
         {
             var req = this.Client.AuthenticatedRequest(this.ResourcePath
-                          + "/?check=true&privilege=" + WebUtility.UrlEncode(privilege));
+                          + "/?check=true&privilege=" + Uri.EscapeDataString(privilege));
             req.Method = "HEAD";
 
             try

--- a/conjur-api/Role.cs
+++ b/conjur-api/Role.cs
@@ -28,7 +28,7 @@ namespace Conjur
         internal Role(Client client, string kind, string name)
             : base(client, kind, name)
         {
-            this.path = $"authz/{WebUtility.UrlEncode(client.GetAccountName())}/roles/{WebUtility.UrlEncode(kind)}/{WebUtility.UrlEncode(name)}";
+            this.path = $"authz/{Uri.EscapeDataString(client.GetAccountName())}/roles/{Uri.EscapeDataString(kind)}/{Uri.EscapeDataString(name)}";
         }
 
         /// <summary>


### PR DESCRIPTION
Same as https://github.com/cyberark/conjur-api-dotnet/pull/25 
**But for V4 SDK.**

**What does this pull request do?**
Fix space issue while loading policy which contains space at URL

**What background context can you provide?**
Until now we used `WebUtility.UrlEncode(" ")` which yields `"+"` instead of `%20` resulting in Conjur Ngnix error and trimming of URL.

**Where should the reviewer start?**
It seems like many classes to review, however the critical change was at the C'tor at path member. Notice that not all the URL get encoded, just the input variables. Therefore there will be no change to other special char like "?" or "&".

Look at the variableTest for a good example.

**How should this be manually tested?**
Create simple policy with: policy, variable resources that contain spaces. e.g:
```
- !policy
   id: demo vault

- !variable
   id: demo variable
```

and load it using V4 .NET SDK and compare it to same policy loaded from CLI viewing result in UI
and Conjur Ngnix log.


**Link to build in Jenkins (if appropriate)**
https://jenkins.conjur.net/view/Conjur%205.x/job/cyberark--conjur-api-dotnet/

**Questions:**
 - Why using `Uri.EscapeDataStrin` instead of `EscapeUriString`?
https://stackoverflow.com/questions/4396598/whats-the-difference-between-escapeuristring-and-escapedatastring
https://stackoverflow.com/questions/602642/server-urlencode-vs-httputility-urlencode/47877559#47877559
TL;DR:
There is no valid reason to ever use Uri.EscapeUriString. If you need to percent-encode a string, always use Uri.EscapeDataString.