### PR TITLE
Fix id to name bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+## 1.4.1 - 2018-10-24
+### Fixed
+- Fixed IdToName in ListResources bug
+
 ## 1.4.0 - 2018-07-05
 - Add Role entity with all corresponding methods
 

--- a/conjur-api/Properties/AssemblyInfo.cs
+++ b/conjur-api/Properties/AssemblyInfo.cs
@@ -19,7 +19,7 @@ using System.Runtime.CompilerServices;
 /// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
 /// The form "{Major}.{Minor}.*" will automatically update the build and revision,
 /// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-[assembly: AssemblyVersion("1.4.0.*")]
+[assembly: AssemblyVersion("1.4.1.*")]
 
 #if (!SIGNING)
 [assembly: InternalsVisibleTo("ConjurTest")]

--- a/conjur-api/Resource.cs
+++ b/conjur-api/Resource.cs
@@ -9,6 +9,7 @@ namespace Conjur
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net;
 
     /// <summary>
@@ -21,7 +22,7 @@ namespace Conjur
         /// </summary>
         protected readonly Client Client;
         private const uint LIMIT_SEARCH_VAR_LIST_RETURNED = 1000;
-
+        private const int ID_PARTS_COUNT = 3;
         private readonly string kind;
         private string resourcePath;
         
@@ -70,6 +71,16 @@ namespace Conjur
 
                 offset += (uint)resultList.Count;
             } while (resultList.Count > 0);
+        }
+
+        /// <summary>
+        /// Parse Conjur id following format of acount:kind:name to extract name.
+        /// </summary>
+        /// <returns>Extracted name from id.</returns>
+        /// <param name="id">Conjur Identifier.</param>
+        protected static string IdToName(string id)
+        {
+            return id.Split(new [] { ':' }, ID_PARTS_COUNT).Last();
         }
 
         /// <summary>

--- a/conjur-api/User.cs
+++ b/conjur-api/User.cs
@@ -34,7 +34,7 @@ namespace Conjur
         /// <returns>Returns IEnumerable to User.</returns>
         internal static IEnumerable<User> List(Client client, string query = null)
         {
-            Func<ResourceMetadata, User> newInst = (searchRes) => new User(client, searchRes.Id);
+            Func<ResourceMetadata, User> newInst = (searchRes) => new User(client, IdToName(searchRes.Id));
             return ListResources<User, ResourceMetadata>(client, "user", newInst, query);
         }
     }

--- a/conjur-api/Variable.cs
+++ b/conjur-api/Variable.cs
@@ -70,7 +70,7 @@ namespace Conjur
         /// <returns>Returns IEnumerable to Variable.</returns>
         internal static IEnumerable<Variable> List(Client client, string query = null)
         {
-            Func<ResourceMetadata, Variable> newInst = (searchRes) => new Variable(client, searchRes.Id);
+            Func<ResourceMetadata, Variable> newInst = (searchRes) => new Variable(client, IdToName(searchRes.Id));
             return ListResources<Variable, ResourceMetadata>(client, "variable", newInst, query);
         }
     }

--- a/test/UsersTest.cs
+++ b/test/UsersTest.cs
@@ -52,7 +52,7 @@ namespace Conjur.Test
         {
             for(int id = 0; id < expectedNumUsers; ++id) {
                 Assert.AreEqual(true, users.MoveNext());
-                Assert.AreEqual($"abc:user:{id}-admin@AutomationVault{id}", users.Current.Id);
+                Assert.AreEqual($"{id}-admin@AutomationVault{id}", users.Current.Id);
             }
             Assert.AreEqual(false, users.MoveNext());
         }


### PR DESCRIPTION
**What does this pull request do?**
Fixing an id to name bug in list resources functionality.
**What background context can you provide?**
Both User and Variable ctors expect to receive a Name of a resource.
List Variables and Users APIs returns a JSON with full Id of the resource: `account:kind:name`.
We used this ID straight forward in order to create Variables and Users in corresponded list resources functions. It caused to those resources to be useless because they treated this full id as only a name.
**Where should the reviewer start?**
conjur-api/Resource.cs