### PR TITLE
Fix malformed mime type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix mime type "text/plain"
+  [cyberark/conjur-api-dotnet#82](https://github.com/cyberark/conjur-api-dotnet/pull/82)
 
 ## [2.1.0] - 2021-09-08
 ### Added

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
           BUILD_NAME = "${env.BUILD_NUMBER}-${env.BRANCH_NAME.replace('/','-')}"
           sh "summon -e pipeline ./build.sh ${BUILD_NAME}"
         }
-        step([$class: 'XUnitBuilder',
+        step([$class: 'XUnitPublisher',
           tools: [[$class: 'NUnitJunitHudsonTestType', pattern: 'TestResult.xml']]])
         archiveArtifacts artifacts: 'bin/*', fingerprint: true
       }

--- a/conjur-api/Variable.cs
+++ b/conjur-api/Variable.cs
@@ -62,7 +62,7 @@ namespace Conjur
                 (webRequest as HttpWebRequest).AllowWriteStreamBuffering = false;
             }
 
-            webRequest.ContentType = "text\\plain";
+            webRequest.ContentType = "text/plain";
             webRequest.ContentLength = val.Length;
             using (Stream requestStream = webRequest.GetRequestStream())
             {

--- a/test/VariablesTest.cs
+++ b/test/VariablesTest.cs
@@ -35,7 +35,7 @@ namespace Conjur.Test
             {
                 MockRequest req = wr as WebMocker.MockRequest;
                 Assert.AreEqual(WebRequestMethods.Http.Post, wr.Method);
-                Assert.AreEqual("text\\plain", wr.ContentType);
+                Assert.AreEqual("text/plain", wr.ContentType);
                 Assert.AreEqual(testValue, req.Body);
             };
             Client.Variable("foobar").AddSecret(Encoding.UTF8.GetBytes(testValue));


### PR DESCRIPTION
### Desired Outcome

Fix error
```
ActionDispatch::Http::MimeNegotiation::InvalidType ("text
plain" is not a valid MIME type)
```

### Implemented Changes

- Changed the "text\plain" (backslash) mime type to "text/plain" (forward slash)

### Connected Issue/Story

CyberArk internal issue link: [ONYX-17641](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-17641)

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
